### PR TITLE
fix: format week start using local timezone

### DIFF
--- a/src/app/api/weeks/[weekStart]/preview/route.ts
+++ b/src/app/api/weeks/[weekStart]/preview/route.ts
@@ -6,6 +6,10 @@ import { authOptions } from '@/lib/auth'
 import { mergeAdjacentPeriods } from '@/lib/schedule-utils'
 import { ScheduleEvent } from '@/lib/types'
 
+function formatDateLocal(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' })
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ weekStart: string }> }
@@ -191,7 +195,7 @@ export async function POST(
     
     return NextResponse.json({ 
       changes,
-      weekStart: weekStart.toISOString().split('T')[0],
+      weekStart: formatDateLocal(weekStart),
       totalChanges
     })
   } catch (error) {

--- a/src/app/api/weeks/[weekStart]/route.ts
+++ b/src/app/api/weeks/[weekStart]/route.ts
@@ -4,6 +4,10 @@ import { prisma } from '@/lib/prisma'
 import { authOptions } from '@/lib/auth'
 import { WeekSchedule } from '@/lib/types'
 
+function formatDateLocal(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' })
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ weekStart: string }> }
@@ -84,7 +88,7 @@ export async function GET(
 
     return NextResponse.json({ 
       schedule,
-      weekStart: weekStart.toISOString().split('T')[0],
+      weekStart: formatDateLocal(weekStart),
       totalEvents
     })
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,6 +31,11 @@ import { useNavbarHeight } from '@/lib/hooks'
 import { toast } from 'sonner'
 
 
+function formatDateLocal(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' })
+}
+
+
 export default function Home() {
   const { data: session, status } = useSession()
   const navbarRef = useRef<HTMLElement>(null)
@@ -101,7 +106,7 @@ export default function Home() {
   const loadWeekSchedule = useCallback(async (week: Date) => {
     setIsLoadingSchedule(true)
     try {
-      const weekStartStr = week.toISOString().split('T')[0]
+      const weekStartStr = formatDateLocal(week)
       const response = await fetch(`/api/weeks/${weekStartStr}`)
       
       if (response.ok) {
@@ -143,7 +148,7 @@ export default function Home() {
 
   const syncDeletedEvents = useCallback(async (week: Date) => {
     try {
-      const weekStartStr = week.toISOString().split('T')[0]
+      const weekStartStr = formatDateLocal(week)
       console.log('🔄 [SyncDeleted] Starting sync for deleted events for week:', weekStartStr)
       
       const response = await fetch(`/api/weeks/${weekStartStr}/sync-deleted`, {
@@ -194,7 +199,7 @@ export default function Home() {
       return
     }
     
-    const weekStartStr = currentWeek.toISOString().split('T')[0]
+    const weekStartStr = formatDateLocal(currentWeek)
     console.log('🔍 [Preview] Starting preview for week:', weekStartStr)
     console.log('🔍 [Preview] Current schedule data:', schedule)
     
@@ -238,7 +243,7 @@ export default function Home() {
       throw new Error('Missing preview changes or current week')
     }
     
-    const weekStartStr = currentWeek.toISOString().split('T')[0]
+    const weekStartStr = formatDateLocal(currentWeek)
     console.log('🔄 [Sync] Starting sync for week:', weekStartStr)
     console.log('🔄 [Sync] Preview changes:', {
       create: previewChanges.create.length,
@@ -540,7 +545,7 @@ export default function Home() {
                         setShowSunday(hasSunday)
                         // 自動保存課表變更 (debounced)
                         if (currentWeek) {
-                          const weekStartStr = currentWeek.toISOString().split('T')[0]
+                          const weekStartStr = formatDateLocal(currentWeek)
                           setTimeout(() => saveScheduleData(weekStartStr, newSchedule), 1000)
                         }
                       }}
@@ -565,7 +570,7 @@ export default function Home() {
                       setShowSunday(hasSunday)
                       // 自動保存課表變更 (debounced)
                       if (currentWeek) {
-                        const weekStartStr = currentWeek.toISOString().split('T')[0]
+                        const weekStartStr = formatDateLocal(currentWeek)
                         setTimeout(() => saveScheduleData(weekStartStr, newSchedule), 1000)
                       }
                     }}

--- a/src/components/schedule/WeekNavigation.tsx
+++ b/src/components/schedule/WeekNavigation.tsx
@@ -6,6 +6,10 @@ import { formatDateRange } from '@/lib/schedule-utils'
 import { toast } from 'sonner'
 import { useState } from 'react'
 
+function formatDateLocal(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' })
+}
+
 interface WeekNavigationProps {
   currentWeek: Date
   onWeekChange: (week: Date) => void
@@ -78,7 +82,7 @@ export default function WeekNavigation({
   const copyPreviousWeek = async () => {
     setIsLoading(true)
     try {
-      const weekStartStr = currentWeek.toISOString().split('T')[0]
+      const weekStartStr = formatDateLocal(currentWeek)
       const response = await fetch(`/api/weeks/${weekStartStr}/copy-previous`, {
         method: 'POST'
       })

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -1,6 +1,10 @@
 import { google } from 'googleapis'
 import { ScheduleEvent } from './types'
 
+function formatDateLocal(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Taipei' })
+}
+
 export interface CalendarEvent {
   id?: string
   summary: string
@@ -219,7 +223,7 @@ export class GoogleCalendarService {
       extendedProperties: {
         private: {
           source: 'class_sync',
-          weekStart: weekStart.toISOString().split('T')[0],
+          weekStart: formatDateLocal(weekStart),
           weekday: scheduleEvent.weekday.toString(),
           periodStart: scheduleEvent.periodStart.toString(),
           periodEnd: scheduleEvent.periodEnd.toString(),


### PR DESCRIPTION
## Summary
- add `formatDateLocal` helper to output `YYYY-MM-DD` in Asia/Taipei
- use local date formatting for `weekStart` when loading, previewing, syncing and copying schedules
- ensure API routes and Google Calendar service send `weekStart` in local time

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68c5765f0b108332ad1abfc17321b277