### PR TITLE
fix: refresh sync preview after schedule edits

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -533,6 +533,7 @@ export default function Home() {
                       bases={bases}
                       onScheduleChange={(newSchedule) => {
                         setSchedule(newSchedule)
+                        setPreviewChanges(undefined)
                         // Auto-detect weekends when schedule changes
                         const hasSaturday = hasSaturdayCourses(newSchedule)
                         const hasSunday = hasSundayCourses(newSchedule)
@@ -558,6 +559,7 @@ export default function Home() {
                     courses={courses}
                     onScheduleChange={(newSchedule) => {
                       setSchedule(newSchedule)
+                      setPreviewChanges(undefined)
                       // Auto-detect weekends when schedule changes
                       const hasSaturday = hasSaturdayCourses(newSchedule)
                       const hasSunday = hasSundayCourses(newSchedule)


### PR DESCRIPTION
## Summary
- clear cached preview results when schedule changes
- ensure sync dialog detects deletions without requiring a page reload

## Testing
- `npm run lint` (fails: A `require()` style import is forbidden)
- `npx eslint src/app/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5780f1ff483328224675493a170a8