### PR TITLE
fix: include Sunday events in calendar sync

### DIFF
--- a/docs/manual-test-sunday-events.md
+++ b/docs/manual-test-sunday-events.md
@@ -1,0 +1,18 @@
+# Manual Test: Verify Sunday Events are Included
+
+1. **Create a Sunday Event**
+   - Sign in to the application and ensure Google Calendar access is granted.
+   - Create an event that occurs on **Sunday** within a week you will test.
+
+2. **Trigger Event Sync**
+   - Navigate to the feature that synchronises your timetable with Google Calendar.
+   - Choose the week that includes the created Sunday event.
+   - Run the sync or refresh logic that calls `listEvents`.
+
+3. **Verify Retrieval**
+   - Inspect the application logs or UI to confirm that the Sunday event appears in the listed results.
+   - The updated `timeMax` now uses next Monday 00:00, so events on Sunday should be returned.
+
+4. **Optional**
+   - Repeat the test with events on other days to ensure behaviour remains unchanged for weekday events.
+

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -38,7 +38,8 @@ export class GoogleCalendarService {
 
   async listEvents(weekStart: Date): Promise<CalendarEvent[]> {
     const weekEnd = new Date(weekStart)
-    weekEnd.setDate(weekStart.getDate() + 6)
+    // Include Sunday events by setting timeMax to next Monday 00:00
+    weekEnd.setDate(weekStart.getDate() + 7)
 
     console.log('🔍 [GoogleCalendar] Listing events:', {
       weekStart: weekStart.toISOString(),


### PR DESCRIPTION
## Summary
- extend calendar event query to next Monday to include Sunday events
- document manual testing steps for Sunday event retrieval

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 575 errors, 1783 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c57abc52b883328cae7d588dfd3838