### PR TITLE
Improve usage dialog formatting and scrolling

### DIFF
--- a/src/components/help/UsageDialog.tsx
+++ b/src/components/help/UsageDialog.tsx
@@ -33,12 +33,12 @@ function MarkdownStepper({ file }: MarkdownStepperProps) {
   const next = () => setIndex(i => Math.min(i + 1, steps.length - 1))
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="prose max-w-none prose-h1:font-bold prose-h1:text-xl prose-h1:mb-4 prose-ul:list-disc prose-ul:pl-5">
+    <div className="flex h-full flex-col">
+      <div className="prose max-w-none flex-1 overflow-y-auto pr-2 prose-h1:mb-4 prose-h1:text-2xl prose-h1:font-bold prose-h1:leading-relaxed prose-ul:list-disc prose-ul:pl-5">
         <ReactMarkdown>{steps[index] || ''}</ReactMarkdown>
       </div>
       {steps.length > 1 && (
-        <div className="flex justify-between">
+        <div className="mt-4 flex justify-between">
           <Button variant="outline" disabled={index === 0} onClick={prev}>
             上一步
           </Button>
@@ -59,23 +59,23 @@ interface UsageDialogProps {
 export default function UsageDialog({ open, onOpenChange }: UsageDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-w-3xl max-h-[70vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>使用說明</DialogTitle>
         </DialogHeader>
-        <Tabs defaultValue="schedule" className="w-full">
-          <TabsList className="mb-4">
+        <Tabs defaultValue="schedule" className="w-full flex-1 overflow-hidden">
+          <TabsList className="mb-4 flex-shrink-0">
             <TabsTrigger value="schedule">週課表說明</TabsTrigger>
             <TabsTrigger value="courses">課程庫說明</TabsTrigger>
             <TabsTrigger value="rooms">教室庫說明</TabsTrigger>
           </TabsList>
-          <TabsContent value="schedule">
+          <TabsContent value="schedule" className="h-full">
             <MarkdownStepper file="/instructions/schedule.md" />
           </TabsContent>
-          <TabsContent value="courses">
+          <TabsContent value="courses" className="h-full">
             <MarkdownStepper file="/instructions/courses.md" />
           </TabsContent>
-          <TabsContent value="rooms">
+          <TabsContent value="rooms" className="h-full">
             <MarkdownStepper file="/instructions/rooms.md" />
           </TabsContent>
         </Tabs>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,11 @@
 import type { Config } from 'tailwindcss'
+import typography from '@tailwindcss/typography'
 
 export default {
   content: [
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   plugins: [
-    require('@tailwindcss/typography'),
+    typography,
   ],
 } satisfies Config


### PR DESCRIPTION
## Summary
- Enhance UsageDialog markdown rendering with larger step titles and bullet lists
- Limit usage dialog height to 70% viewport and make content scrollable while keeping navigation buttons fixed
- Use ES module import for Tailwind typography plugin to satisfy linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64f78f5708332a1462413211e04e6