### PR TITLE
Bind local schedules to their week

### DIFF
--- a/src/lib/local-schedule.ts
+++ b/src/lib/local-schedule.ts
@@ -1,0 +1,22 @@
+import { WeekSchedule } from './types'
+
+const STORAGE_PREFIX = 'schedule-'
+
+export function loadLocalSchedule(weekStart: string): WeekSchedule | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const data = window.localStorage.getItem(`${STORAGE_PREFIX}${weekStart}`)
+    return data ? (JSON.parse(data) as WeekSchedule) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveLocalSchedule(weekStart: string, schedule: WeekSchedule): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(`${STORAGE_PREFIX}${weekStart}`, JSON.stringify(schedule))
+  } catch {
+    // Ignore write errors
+  }
+}


### PR DESCRIPTION
## Summary
- store weekly schedules in localStorage by week start
- merge server data with week-specific local cache only
- allow week switching even when previous edits weren't saved

## Testing
- `npm test` *(fails: Missing script)*
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c67c4f1fd88332b6e864a1a796dcb5